### PR TITLE
Add support for alias actions and include a few default aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,20 @@ Be sure to place `require gistyle` before `require_tree .`.
       init: function() {
         console.log("home controller wide");
       },
-      index: function(){
+      index: function() {
         console.log("home#index");
+      },
+      new: function() {
+        console.log("home#new");
+      },
+      _new_create: function() {
+        console.log("home#new or home#create)");
+      },
+      _edit_update: function() {
+        console.log("home#edit or home#update)");
+      },
+      _form: function() {
+        console.log("Action with form (by default new, create, edit and update). See aliases (below) for more info.");
       },
       about: function() {
         console.log("home#about");
@@ -73,3 +85,17 @@ Be sure to place `require gistyle` before `require_tree .`.
         this.subroutine()
       subroutine () ->
         # blablabla
+
+### Aliases
+It is possible to define aliases, i.e. actions that (also) trigger another action. This is useful to for example have an action _form that is triggered for all actions with a form (by default new, create, edit and update).
+
+Aliases are defined by calling: `GIStyle.alias(controller, action_from, action_to)`. It is also possible to define general aliases for all controllers by setting controller to `undefined`.
+
+A few general aliases are included by default:
+* `new`, `create`, `edit`, `update` => `_form`
+* `new`, `create` => `_new_create`
+* `edit`, `update` => `_new_update`
+
+Aliases can be cleared by calling either:
+* `GIStyle.clear_aliases_for_controller(controller)` or
+* `GIStyle.clear_all_aliases()`.

--- a/vendor/assets/javascripts/gistyle.js
+++ b/vendor/assets/javascripts/gistyle.js
@@ -1,26 +1,68 @@
 // Inspired from Paul Irish and Jason Garber
 
 APP = {};
- 
+
 GIStyle = {
+  aliases: {}, // Aliases per controller. '*' matches all controllers.
+
+  alias: function( controller, from, to ) {
+    if ( controller === undefined )
+      controller = "*";
+    if ( GIStyle.aliases[controller] === undefined )
+      GIStyle.aliases[controller] = {};
+    if ( GIStyle.aliases[controller][from] === undefined )
+      GIStyle.aliases[controller][from] = [];
+
+    GIStyle.aliases[controller][from].push(to);
+  },
+
+  clear_all_aliases: function() {
+    GIStyle.aliases = {}
+  },
+
+  clear_aliases_for_controller: function( controller ) {
+    GIStyle.aliases[controller] = {}
+  },
+
   exec: function( controller, action ) {
     var ns = APP, action = ( action === undefined ) ? "init" : action;
- 
+
+    // First execute aliases for this action
+    if(GIStyle.aliases['*'] !== undefined && GIStyle.aliases['*'][action] !== undefined) {
+      $.each(GIStyle.aliases['*'][action], function( index, alias ) {
+        GIStyle.exec(controller, alias);
+      });
+    }
+    if(GIStyle.aliases[controller] !== undefined && GIStyle.aliases[controller][action] !== undefined) {
+      $.each(GIStyle.aliases[controller][action], function( index, alias ) {
+        GIStyle.exec(controller, alias);
+      });
+    }
+
+    // Then execute function for this action
     if ( controller !== "" && ns[controller] && typeof ns[controller][action] == "function" ) {
       ns[controller][action]();
     }
   },
- 
+
   init: function() {
     var body = document.body,
         controller = body.getAttribute("data-controller"),
         action = body.getAttribute("data-action");
- 
+
     if(typeof APP.init == "function") APP.init();
     GIStyle.exec(controller);
     GIStyle.exec(controller, action);
   }
 };
 
+// Add default aliases for all controllers (new, create, edit and update actions also call form action)
+GIStyle.alias(undefined, 'new', '_new_create');
+GIStyle.alias(undefined, 'create', '_new_create');
+GIStyle.alias(undefined, '_new_create', '_form');
+GIStyle.alias(undefined, 'edit', '_edit_update');
+GIStyle.alias(undefined, 'update', '_edit_update');
+GIStyle.alias(undefined, '_edit_update', '_form');
+
 $(document).ready(GIStyle.init);
-$(document).on('page:load', GIStyle.init) // support Turbolinks
+$(document).on('page:load', GIStyle.init) // Support Turbolinks


### PR DESCRIPTION
Add the ability to define alias actions. This way it is easier to define JavaScript for similar actions that is triggered for all these actions. An example are the commonly used new, create, edit and update actions in Rails, which will now also trigger the _form alias.

Now it is not necessary to put the same JavaScript in four actions (or create a function for it that is called in all four actions manually). This simply happens automatically.

It is possible to define controller specific and controller-wide (general) aliases.
