### PR TITLE
Fix for turbolinks with legacy browsers

### DIFF
--- a/vendor/assets/javascripts/gistyle.js
+++ b/vendor/assets/javascripts/gistyle.js
@@ -64,4 +64,5 @@ GIStyle.alias(undefined, 'edit', '_edit_update');
 GIStyle.alias(undefined, 'update', '_edit_update');
 GIStyle.alias(undefined, '_edit_update', '_form');
 
-$(document).on(typeof(Turbolinks) == 'undefined' ? 'ready' : 'page:change', GIStyle.init) // support Turbolinks
+var turbolinkSupported = typeof(Turbolinks) !== "undefined" && Turbolinks !== null && Turbolinks.supported;
+$(document).on(turbolinkSupported ? 'page:change' : 'ready', GIStyle.init);


### PR DESCRIPTION
Turbolinks will not enable itself if the browser can not support it, e.g. Internet Explorer 8.
So merely checking Turbolinks constant is not enough, we need to also check the `supported` property.

There are two commits, the first one just check `supported`. However that property is only present after Turbolinks 2.0, therefore will raise error for users of older Turbolinks.

The second commit will return true if `supported` is not there but `Turbolinks` is present, so it will work for older Turbolinks (but will still have this bug).

You can choose which one you like :)
